### PR TITLE
Patch issue 1

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,11 @@
 #include "include/logger.h"
 
 int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        std::cout << "Usage: quickc <file> <flags file> [args]" << std::endl;
+        std::cout << "For help run quickc -quickh" << std::endl;
+        return 1;
+    }
     bool verbose = false;
     bool log_to_file = false;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,8 +16,15 @@
 int main(int argc, char *argv[]) {
     bool verbose = false;
     bool log_to_file = false;
+
     std::string file = argv[1];
-    std::string flags_file = argv[2];
+    std::string flags_file;
+    if (argc > 2) {
+        flags_file = argv[2];
+    } else {
+        flags_file = ".";
+    }
+
     std::string args = "";
     for (int i = 3; i < argc; i++) {
         args += argv[i];


### PR DESCRIPTION
## Fix: abort when no flags file argument is given
Closes https://github.com/awesomelewis2007/quickc/issues/1
Fix program abort when no flags file argument is given.
Example:
```
quickc test.c
```

Output:
```
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
fish: Job 1, '.quickc test.c' terminated by signal SIGABRT (Abort)
```

After patch:
```
quickc test.c
```

Output:
```
<RUNS CORRECTLY>
```

If the user was to run quickc without any flags file argument then
the program would have aborted. This patch fixes that bug by checking
if the arguments given is greater or equal to 3 and if it is then it
will read the third argument as the flags file. If the arguments given
is less than 3 then it will set the flags file to the default flags which
is marked as "." in the code.

## Add message if no arguments are passed 
This adds a message if no arguments are passed to the program.

If the arguments entered is less than 2, then the program will
print a message and exit. This is to prevent the program from
running without any arguments.